### PR TITLE
Fixed a fatal error showing on UBC Blogs where the function gets call…

### DIFF
--- a/wp-caliper-event-hooks.php
+++ b/wp-caliper-event-hooks.php
@@ -443,7 +443,7 @@ add_action( 'wp_login', 'WPCaliperPlugin\\wp_caliper_wp_login', 10, 2 );
  * @param bool     $user_login user login.
  * @param \WP_USER $user WordPress user object.
  */
-function wp_caliper_wp_login( $user_login, $user ) {
+function wp_caliper_wp_login( $user_login = false, $user = false ) {
 	if ( empty( $user->ID ) ) {
 		return;
 	}


### PR DESCRIPTION
Fixed a fatal error showing on UBC Blogs where the function gets called early and did not pass enough parameters it needs. Error below

Uncaught ArgumentCountError: Too few arguments to function WPCaliperPlugin\\wp_caliper_wp_login(), 1 passed in /www_data/www/wp-includes/class-wp-hook.php on line 307 and exactly 2 expected in /www_data/www/wp-content/mu-plugins/wp-caliper/wp-caliper-event-hooks.php:446